### PR TITLE
Refactor Ludo Game Engine Architecture

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -10,11 +10,11 @@ plugins {
 // Load the keystore properties
 def keystoreProperties = new Properties()
 def keystorePropertiesFile = file("../../key.properties")
-if (keystorePropertiesFile.exists()) {
+def hasKeyProperties = keystorePropertiesFile.exists()
+if (hasKeyProperties) {
     keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
-} else {
-    throw new GradleException("key.properties file not found")
 }
+
 
 android {
     namespace = "com.trakbit.ludozone"
@@ -35,16 +35,22 @@ android {
         versionName = flutter.versionName
     }
     signingConfigs {
-        release {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
+        if (hasKeyProperties) {
+            release {
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+                storeFile file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+            }
         }
     }
     buildTypes {
         release {
-            signingConfig signingConfigs.release
+            if (hasKeyProperties) {
+                signingConfig signingConfigs.release
+            } else {
+                signingConfig signingConfigs.debug
+            }
         }
     }
 }

--- a/lib/component/home/home.dart
+++ b/lib/component/home/home.dart
@@ -7,6 +7,7 @@ class Home extends RectangleComponent {
     required double size,
     required Paint? paint,
     required Paint homeSpotColor,
+    required String teamCode,
     List<Component>? children,
   }) : super(
           size: Vector2.all(size),
@@ -25,6 +26,7 @@ class Home extends RectangleComponent {
               size: size / 1.5,
               position: Vector2.all(size / 2 - size / 3), // Simplified center calculation
               homeSpotColor: homeSpotColor,
+              teamCode: teamCode,
             ),
           ],
         );

--- a/lib/component/home/home_plate.dart
+++ b/lib/component/home/home_plate.dart
@@ -8,6 +8,7 @@ class HomePlate extends RectangleComponent {
     required double size,
     required Vector2 position,
     required Paint homeSpotColor,
+    required String teamCode,
   }) : super(
           size: Vector2.all(size),
           position: position,
@@ -27,6 +28,7 @@ class HomePlate extends RectangleComponent {
               position: position / 1.5,
               homeSpotColor: homeSpotColor,
               radius: size / 8,
+              teamCode: teamCode,
             ),
           ],
         );

--- a/lib/component/home/home_spot.dart
+++ b/lib/component/home/home_spot.dart
@@ -6,8 +6,7 @@ class HomeSpot extends CircleComponent {
   static final Paint borderPaint = Paint()
     ..color = Colors.transparent // Keep interior transparent
     ..style = PaintingStyle.stroke // Set to stroke for the border
-    ..strokeWidth = 1.0 // Set border width
-    ..color =Colors.transparent; // Set border color to black
+    ..strokeWidth = 1.0; // Set border width
 
   HomeSpot({
     required double radius,

--- a/lib/component/home/home_spot_container.dart
+++ b/lib/component/home/home_spot_container.dart
@@ -3,11 +3,14 @@ import 'package:flutter/material.dart';
 import 'home_spot.dart';
 
 class HomeSpotContainer extends RectangleComponent {
+  final String teamCode;
+
   HomeSpotContainer({
     required double size,
     required Vector2 position,
     required Paint homeSpotColor,
     required double radius,
+    required this.teamCode,
   }) : super(
           size: Vector2.all(size),
           position: position,
@@ -18,8 +21,6 @@ class HomeSpotContainer extends RectangleComponent {
 
   // Method to create home spots with unique IDs
   void _createHomeSpots(Paint homeSpotColor, double radius) {
-    String colorCode = _getColorCode(homeSpotColor);
-
     // Pre-calculate positions for each slot
     final positions = [
       Vector2(0, 0), // Top-left
@@ -29,7 +30,7 @@ class HomeSpotContainer extends RectangleComponent {
     ];
 
     for (int slotNumber = 0; slotNumber < 4; slotNumber++) {
-      String uniqueId = '$colorCode${slotNumber + 1}';
+      String uniqueId = '$teamCode${slotNumber + 1}';
 
       HomeSpot homeSpot = HomeSpot(
         radius: radius,
@@ -38,23 +39,6 @@ class HomeSpotContainer extends RectangleComponent {
         uniqueId: uniqueId, // Assign uniqueId to each HomeSpot
       );
       add(homeSpot);
-    }
-  }
-
-  // Helper method to get the color code from the Paint object
-  String _getColorCode(Paint paint) {
-    Color color = paint.color;
-    switch (color.value) {
-      case 0xffFF5B5B:
-        return 'R';
-      case 0xFF41B06E:
-        return 'G';
-      case 0xFF0D92F4:
-        return 'B';
-      case 0xFFFFD966:
-        return 'Y';
-      default:
-        return 'U'; // For unknown colors
     }
   }
 }

--- a/lib/component/ui_components/ludo_dice.dart
+++ b/lib/component/ui_components/ludo_dice.dart
@@ -15,7 +15,7 @@ import '../controller/lower_controller.dart';
 import 'token.dart';
 import '../../ludo.dart';
 
-class LudoDice extends PositionComponent with TapCallbacks {
+class LudoDice extends PositionComponent with TapCallbacks, HasGameReference<Ludo> {
   static const double borderRadiusFactor =
       0.2; // Precomputed factor for border radius
   static const double innerSizeFactor =
@@ -45,7 +45,7 @@ class LudoDice extends PositionComponent with TapCallbacks {
     }
 
     // Disable dice to prevent multiple taps
-    final world = parent?.parent?.parent?.parent?.parent;
+    final world = game.world;
     GameState().hidePointer();
     player.enableDice = false;
 

--- a/lib/component/ui_components/rank_modal_component.dart
+++ b/lib/component/ui_components/rank_modal_component.dart
@@ -178,10 +178,7 @@ class RankModalComponent extends PositionComponent with TapCallbacks {
 
     // Check if the tap is within the button's bounds
     if (_closeButton.toRect().contains(tapPosition)) {
-      Navigator.push(
-        context,
-        MaterialPageRoute(builder: (context) => const FirstScreen()),
-      );
+      Navigator.of(context).popUntil((route) => route.isFirst);
     }
   }
 

--- a/lib/component/ui_components/token.dart
+++ b/lib/component/ui_components/token.dart
@@ -12,7 +12,7 @@ enum TokenState {
   inHome,
 }
 
-class Token extends PositionComponent with TapCallbacks {
+class Token extends PositionComponent with TapCallbacks, HasGameReference<Ludo> {
   final String tokenId; // Mandatory unique ID for the token
   String playerId; // Store only the player ID
   bool enableToken; // Store the enableToken state directly
@@ -131,11 +131,10 @@ class Token extends PositionComponent with TapCallbacks {
   void onTapDown(TapDownEvent event) async {
     super.onTapDown(event);
 
-    final world = parent?.parent;
+    final world = game.world;
 
     if (!spaceToMove() ||
         !enableToken ||
-        world is! World ||
         (isInBase() && GameState().diceNumber != 6) ||
         isInHome()) return;
 

--- a/lib/ludo_board.dart
+++ b/lib/ludo_board.dart
@@ -38,6 +38,7 @@ class LudoBoard extends PositionComponent {
             size: longDimension,
             paint: Paint()..color = GameState().red,
             homeSpotColor: Paint()..color = GameState().red,
+            teamCode: 'R',
           )
         ]);
 
@@ -57,6 +58,7 @@ class LudoBoard extends PositionComponent {
             size: longDimension,
             paint: Paint()..color = GameState().green,
             homeSpotColor: Paint()..color = GameState().green,
+            teamCode: 'G',
           )
         ]);
 
@@ -88,6 +90,7 @@ class LudoBoard extends PositionComponent {
             size: longDimension,
             paint: Paint()..color =GameState().blue,
             homeSpotColor: Paint()..color = GameState().blue,
+            teamCode: 'B',
           )
         ]);
 
@@ -107,6 +110,7 @@ class LudoBoard extends PositionComponent {
             size: longDimension,
             paint: Paint()..color = GameState().yellow,
             homeSpotColor: Paint()..color = GameState().yellow,
+            teamCode: 'Y',
           )
         ]);
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -356,12 +356,7 @@ class _GameAppState extends State<GameApp> {
             ),
             TextButton(
               onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => const FirstScreen(),
-                  ),
-                );
+                Navigator.of(context).popUntil((route) => route.isFirst);
               },
               child: const Text('Yes'),
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: "ludo board game"
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.0+10
+version: 1.0.1+11
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
Refactors Ludo game engine architecture:
- Decouples color/visuals from team IDs ('R', 'G', 'B', 'Y')
- Replaces fragile parent-traversal component lookups with type-safe HasGameReference mixin
- Fixes navigation route memory leaks by popping routes back to first screen instead of pushing duplicates
- Cleans up duplicate properties in HomeSpot