### PR TITLE
Ignore root key.properties in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ app.*.map.json
 /android/gradlew*
 /android/local.properties
 /android/key.properties
+/key.properties
 
 # CMake build artifacts (these should NEVER be in Git)
 **/.cxx/


### PR DESCRIPTION
Adds root key.properties to gitignore to prevent accidental credential commits.