### PR TITLE
Support 16 KB memory page sizes on Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -19,7 +19,7 @@ if (hasKeyProperties) {
 android {
     namespace = "com.trakbit.ludozone"
     compileSdk = 35  // Override Flutter's default to target API 35
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.1.12297006"
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,3 +18,20 @@ subprojects {
 tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }
+
+subprojects {
+    def setNdk = {
+        if (hasProperty("android")) {
+            android {
+                ndkVersion = "27.1.12297006"
+            }
+        }
+    }
+    if (state.executed) {
+        setNdk()
+    } else {
+        afterEvaluate {
+            setNdk()
+        }
+    }
+}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -20,7 +20,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.4.1" apply false
+    id "com.android.application" version "8.5.2" apply false
     id "org.jetbrains.kotlin.android" version "1.9.23" apply false
 }
 


### PR DESCRIPTION
Upgrades:
- Android Gradle Plugin (AGP) to 8.5.2
- Pinned NDK to 27.1.12297006 globally for all plugins

Aligns all compiled native libraries (.so) to 16 KB boundaries for PlayStore requirements.