### PR TITLE
Refactor Ludo architecture and clean up UI components

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,13 +9,7 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
-analyzer:
-  errors:
-    deprecated_member_use: ignore
-    use_super_parameters: ignore
-    prefer_const_constructors: ignore
-    curly_braces_in_flow_control_structures: ignore
-    prefer_conditional_assignment: ignore
+
 
 
 linter:

--- a/lib/component/controller/controller_block.dart
+++ b/lib/component/controller/controller_block.dart
@@ -16,7 +16,7 @@ class ControllerBlock extends PositionComponent {
     this.transparentLeft = false,
     List<Component>? children, // Optional child components
   })  : strokePaint = Paint()
-          ..color = paint.color.withOpacity(1.0)
+          ..color = paint.color.withValues(alpha: 1.0)
           ..style = PaintingStyle.stroke
           ..strokeWidth = strokeWidth,
         super(
@@ -30,7 +30,7 @@ class ControllerBlock extends PositionComponent {
     // Draw the filled rectangle
     final rect = Rect.fromLTWH(0, 0, size.x, size.y);
     canvas.drawRect(rect,
-        Paint()..color = strokePaint.color.withOpacity(0)); // Transparent fill
+        Paint()..color = strokePaint.color.withValues(alpha: 0.0)); // Transparent fill
 
     // Stroke paint for sides
     final transparentStrokePaint = Paint()

--- a/lib/component/home/home_plate.dart
+++ b/lib/component/home/home_plate.dart
@@ -21,7 +21,7 @@ class HomePlate extends RectangleComponent {
                 ..color = Colors.transparent // Keep interior transparent
                 ..style = PaintingStyle.stroke // Set style to stroke
                 ..strokeWidth =4 // Set border width
-                ..color = Colors.black.withOpacity(0.2), // Set border color to black
+                ..color = Colors.black.withValues(alpha: 0.2), // Set border color to black
             ),
             HomeSpotContainer(
               size: size / 1.5,

--- a/lib/component/home/home_spot.dart
+++ b/lib/component/home/home_spot.dart
@@ -1,5 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flutter/material.dart';
+import 'package:ludo/state/home_spot_manager.dart';
 
 class HomeSpot extends CircleComponent {
   final String uniqueId;
@@ -24,5 +25,7 @@ class HomeSpot extends CircleComponent {
               paint: borderPaint, // Reuse static border paint
             ),
           ],
-        );
+        ) {
+    HomeSpotManager().addHomeSpot(this);
+  }
 }

--- a/lib/component/ui_components/dice_pointer.dart
+++ b/lib/component/ui_components/dice_pointer.dart
@@ -11,8 +11,8 @@ class DicePointer extends PositionComponent {
     required double size,
     required this.paint,
     required this.direction,
-    Vector2? position,
-  }) : super(size: Vector2.all(size), position: position);
+    super.position,
+  }) : super(size: Vector2.all(size));
 
   @override
   void render(Canvas canvas) {

--- a/lib/component/ui_components/ludo_dice.dart
+++ b/lib/component/ui_components/ludo_dice.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math';
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame/effects.dart';
@@ -10,8 +9,6 @@ import 'dice_face_component.dart';
 import '../../state/game_state.dart';
 import '../../state/audio_manager.dart';
 import '../../state/player.dart';
-import '../../ludo_board.dart';
-import 'token.dart';
 import '../../ludo.dart';
 
 class LudoDice extends PositionComponent with TapCallbacks, HasGameReference<Ludo> {
@@ -49,8 +46,8 @@ class LudoDice extends PositionComponent with TapCallbacks, HasGameReference<Lud
     player.enableDice = false;
 
     // Roll the dice and update the dice face
-    GameState().diceNumber = Random().nextInt(6) + 1;
-    diceFace.updateDiceValue(GameState().diceNumber);
+    final rolledNumber = GameState().rollDice();
+    diceFace.updateDiceValue(rolledNumber);
 
     playSound();
     // Apply dice rotation effect
@@ -58,11 +55,8 @@ class LudoDice extends PositionComponent with TapCallbacks, HasGameReference<Lud
 
     await Future.delayed(const Duration(milliseconds: 300));
 
-    // Handle dice roll based on the number
-    final handleRoll =
-        GameState().diceNumber == 6 ? _handleSixRoll : _handleNonSixRoll;
-    handleRoll(
-        world, GameState().ludoBoard as LudoBoard, GameState().diceNumber);
+    // Resolve the roll logic on the GameState controller
+    GameState().resolveDiceRoll(world);
   }
 
   // Apply a 360-degree rotation effect to the dice
@@ -77,113 +71,6 @@ class LudoDice extends PositionComponent with TapCallbacks, HasGameReference<Lud
       ),
     );
     return Future.value();
-  }
-
-  // Handle logic when the player rolls a 6
-  void _handleSixRoll(World world, LudoBoard ludoBoard, int diceNumber) {
-    player.grantAnotherTurn();
-
-    if (player.hasRolledThreeConsecutiveSixes()) {
-      GameState().switchToNextPlayer();
-      return;
-    }
-    // Filter tokens once and reuse the lists
-    final tokensInBase = player.tokens
-        .where((token) => token.state == TokenState.inBase)
-        .toList();
-
-    final tokensOnBoard = player.tokens
-        .where((token) => token.state == TokenState.onBoard)
-        .toList();
-
-    final movableTokens =
-        tokensOnBoard.where((token) => token.spaceToMove()).toList();
-
-    final allMovableTokens = [...movableTokens, ...tokensInBase];
-
-    // if only one token can move, move it
-    if (allMovableTokens.length == 1) {
-      if (allMovableTokens.first.state == TokenState.inBase) {
-        moveOutOfBase(
-          world: world,
-          token: allMovableTokens.first,
-          tokenPath: GameState().getTokenPath(player.playerId),
-        );
-      } else if (allMovableTokens.first.state == TokenState.onBoard) {
-        _moveForwardSingleToken(
-            world, ludoBoard, diceNumber, allMovableTokens.first);
-      }
-      return;
-    } else if (allMovableTokens.length > 1) {
-      _enableManualTokenSelection(world, tokensInBase, tokensOnBoard);
-    } else if (allMovableTokens.isEmpty) {
-      GameState().switchToNextPlayer();
-      return;
-    }
-  }
-
-  // Handle logic for non-six dice rolls
-  void _handleNonSixRoll(World world, LudoBoard ludoBoard, int diceNumber) {
-    final tokensOnBoard = player.tokens
-        .where((token) => token.state == TokenState.onBoard)
-        .toList();
-
-    // if no tokens on board, switch to next player
-    if (tokensOnBoard.isEmpty) {
-      GameState().switchToNextPlayer();
-      return;
-    }
-
-    final movableTokens =
-        tokensOnBoard.where((token) => token.spaceToMove()).toList();
-    final tokensInBase = player.tokens
-        .where((token) => token.state == TokenState.inBase)
-        .toList();
-
-    // if only one token can move, move it
-    if (movableTokens.length == 1) {
-      _moveForwardSingleToken(
-          world, ludoBoard, diceNumber, movableTokens.first);
-      return;
-    } else if (movableTokens.length > 1) {
-      _enableManualTokenSelection(world, tokensInBase, tokensOnBoard);
-    } else if (movableTokens.isEmpty) {
-      GameState().switchToNextPlayer();
-      return;
-    }
-  }
-
-  // Enable manual selection if multiple tokens can move
-  void _enableManualTokenSelection(
-      World world, List<Token> tokensInBase, List<Token> tokensOnBoard) {
-
-    GameState().hidePointer();
-    player.enableDice = false;
-
-    for (var token in player.tokens) {
-      token.enableToken = true;
-    }
-    if (tokensInBase.isNotEmpty && tokensOnBoard.isNotEmpty) {
-      GameState().enableMoveFromBoth();
-      addTokenTrail(tokensInBase, tokensOnBoard);
-    } else if (tokensInBase.isNotEmpty) {
-      GameState().enableMoveFromBase();
-      addTokenTrail(tokensInBase, tokensOnBoard);
-    } else if (tokensOnBoard.isNotEmpty) {
-      addTokenTrail(tokensInBase, tokensOnBoard);
-      GameState().enableMoveOnBoard();
-    }
-  }
-
-  // Move the token forward on the board
-  void _moveForwardSingleToken(
-      World world, LudoBoard ludoBoard, int diceNumber, Token token) {
-    moveForward(
-      world: world,
-      token: token,
-      tokenPath: GameState().getTokenPath(player.playerId),
-      diceNumber: diceNumber,
-    );
   }
 
   LudoDice({required this.faceSize, required this.player}) {
@@ -230,7 +117,7 @@ class LudoDice extends PositionComponent with TapCallbacks, HasGameReference<Lud
 
     // Create paint for the square
     final paint = Paint()
-      ..color = Color(0xFFD6D6D6)
+      ..color = const Color(0xFFD6D6D6)
       ..style = PaintingStyle.fill;
 
     // Define the rounded rectangle

--- a/lib/component/ui_components/token.dart
+++ b/lib/component/ui_components/token.dart
@@ -1,7 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flutter/material.dart';
-import 'package:ludo/state/token_manager.dart';
 import '../../state/game_state.dart';
 import '../../ludo.dart';
 
@@ -61,7 +60,7 @@ class Token extends PositionComponent with TapCallbacks, HasGameReference<Ludo> 
     final smallerCircleShadow = Offset(size.x / 2, size.y / 1.75);
 
     canvas.drawCircle(tokenShadow, outerRadius,
-        Paint()..color = const Color(0xFF3C3D37).withOpacity(0.6));
+        Paint()..color = const Color(0xFF3C3D37).withValues(alpha: 0.6));
     canvas.drawCircle(centerShadow, sideOuterRadius,
         Paint()..color = sideColor); // Draw outer circle
 
@@ -69,7 +68,7 @@ class Token extends PositionComponent with TapCallbacks, HasGameReference<Ludo> 
         center, outerRadius, Paint()..color = topColor); // Draw border
 
     canvas.drawCircle(smallerCircleShadow, smallerCircleDepth,
-        Paint()..color = const Color(0xFF3C3D37).withOpacity(0.7));
+        Paint()..color = const Color(0xFF3C3D37).withValues(alpha: 0.7));
     canvas.drawCircle(center, smallerCircle, Paint()..color = Colors.white);
 
     // Conditionally render the circle around the token
@@ -82,7 +81,7 @@ class Token extends PositionComponent with TapCallbacks, HasGameReference<Ludo> 
     final center = Offset(size.x / 2, size.y / 1.8);
 
     final paint = Paint()
-      ..color = Colors.black.withOpacity(0.4) // Blue color with transparency
+      ..color = Colors.black.withValues(alpha: 0.4) // Blue color with transparency
       ..style = PaintingStyle.stroke
       ..strokeWidth = 1.8;
 
@@ -128,53 +127,9 @@ class Token extends PositionComponent with TapCallbacks, HasGameReference<Ludo> 
   }
 
   @override
-  void onTapDown(TapDownEvent event) async {
+  void onTapDown(TapDownEvent event) {
     super.onTapDown(event);
-
-    final world = game.world;
-
-    if (!spaceToMove() ||
-        !enableToken ||
-        (isInBase() && GameState().diceNumber != 6) ||
-        isInHome()) return;
-
-    enableToken = false;
-
-    if (GameState().currentPlayer.playerId != playerId) return;
-
-    final tokens = TokenManager().allTokens;
-    for (var token in tokens) {
-      token.disableCircleAnimation();
-      token.enableToken = false;
-    }
-
-    if (GameState().diceNumber == 6) {
-      // Handle movement logic
-      if (state == TokenState.inBase && GameState().canMoveTokenFromBase) {
-        moveOutOfBase(
-            world: world,
-            token: this,
-            tokenPath: GameState().getTokenPath(playerId));
-        // Consider reducing delay or making it conditional
-      } else if (state == TokenState.onBoard &&
-          GameState().canMoveTokenOnBoard) {
-        moveForward(
-            world: world,
-            token: this,
-            tokenPath: GameState().getTokenPath(playerId),
-            diceNumber: GameState().diceNumber);
-      }
-      return;
-    }
-
-    // Non-six logic
-    if (state == TokenState.onBoard && GameState().canMoveTokenOnBoard) {
-      moveForward(
-          world: world,
-          token: this,
-          tokenPath: GameState().getTokenPath(playerId),
-          diceNumber: GameState().diceNumber);
-    }
+    GameState().handleTokenTap(game.world, this);
   }
 
   bool spaceToMove() {

--- a/lib/ludo.dart
+++ b/lib/ludo.dart
@@ -5,22 +5,20 @@ import 'package:flame/events.dart';
 import 'package:flame/game.dart';
 import 'package:flame/effects.dart';
 import 'package:flutter/material.dart';
-import 'package:flame_audio/flame_audio.dart';
 
 import 'state/player.dart';
 import 'component/home/home.dart';
 import 'state/token_manager.dart';
 import 'state/event_bus.dart';
-import 'component/home/home_spot.dart';
 import 'state/game_state.dart';
 import 'state/audio_manager.dart';
 import 'component/controller/upper_controller.dart';
 import 'component/controller/lower_controller.dart';
 import 'ludo_board.dart';
-import 'component/ui_components/token.dart';
 import 'component/ui_components/spot.dart';
 import 'component/ui_components/ludo_dice.dart';
 import 'component/ui_components/rank_modal_component.dart';
+import 'state/home_spot_manager.dart';
 
 class Ludo extends FlameGame
     with HasCollisionDetection, KeyboardEvents, TapDetector {
@@ -381,9 +379,7 @@ class Ludo extends FlameGame
           const tokenSizeFactorY = 1.05;
 
           for (var token in TokenManager().getBlueTokens()) {
-            final homeSpot = getHomeSpot(world, 6)
-                .whereType<HomeSpot>()
-                .firstWhere((spot) => spot.uniqueId == token.positionId);
+            final homeSpot = HomeSpotManager().getHomeSpotById(token.positionId)!;
             final spot = SpotManager().findSpotById(token.positionId);
             // update spot position
             spot.position = Vector2(
@@ -467,9 +463,7 @@ class Ludo extends FlameGame
           const tokenSizeFactorY = 1.05;
 
           for (var token in TokenManager().getGreenTokens()) {
-            final homeSpot = getHomeSpot(world, 2)
-                .whereType<HomeSpot>()
-                .firstWhere((spot) => spot.uniqueId == token.positionId);
+            final homeSpot = HomeSpotManager().getHomeSpotById(token.positionId)!;
             final spot = SpotManager().findSpotById(token.positionId);
             // update spot position
             spot.position = Vector2(
@@ -530,9 +524,7 @@ class Ludo extends FlameGame
           const tokenSizeFactorY = 1.05;
 
           for (var token in TokenManager().getYellowTokens()) {
-            final homeSpot = getHomeSpot(world, 8)
-                .whereType<HomeSpot>()
-                .firstWhere((spot) => spot.uniqueId == token.positionId);
+            final homeSpot = HomeSpotManager().getHomeSpotById(token.positionId)!;
             final spot = SpotManager().findSpotById(token.positionId);
             // update spot position
             spot.position = Vector2(
@@ -614,9 +606,7 @@ class Ludo extends FlameGame
           const tokenSizeFactorY = 1.05;
 
           for (var token in TokenManager().getRedTokens()) {
-            final homeSpot = getHomeSpot(world, 0)
-                .whereType<HomeSpot>()
-                .firstWhere((spot) => spot.uniqueId == token.positionId);
+            final homeSpot = HomeSpotManager().getHomeSpotById(token.positionId)!;
             final spot = SpotManager().findSpotById(token.positionId);
             // update spot position
             spot.position = Vector2(
@@ -713,363 +703,3 @@ class Ludo extends FlameGame
   }
 }
 
-List<Component> getHomeSpot(world, i) {
-  final childrenOfLudoBoard = GameState().ludoBoard?.children.toList();
-  final child = childrenOfLudoBoard![i];
-  final home = child.children.toList();
-  final homePlate = home[0].children.toList();
-  final homeSpotContainer = homePlate[1].children.toList();
-  final homeSpotList = homeSpotContainer[1].children.toList();
-  return homeSpotList;
-}
-
-void moveOutOfBase({
-  required World world,
-  required Token token,
-  required List<String> tokenPath,
-}) async {
-  // Update token position to the first position in the path
-  token.positionId = tokenPath.first;
-  token.state = TokenState.onBoard;
-
-  await _applyEffect(
-      token,
-      MoveToEffect(SpotManager().findSpotById(tokenPath.first).tokenPosition,
-          EffectController(duration: 0.1, curve: Curves.easeInOut)));
-
-  tokenCollision(world, token);
-}
-
-void tokenCollision(World world, Token attackerToken) async {
-  final tokensOnSpot = TokenManager()
-      .allTokens
-      .where((token) => token.positionId == attackerToken.positionId)
-      .toList();
-
-  // Initialize the flag to track if any token was attacked
-  bool wasTokenAttacked = false;
-
-  // only attacker token on spot, return
-  if (tokensOnSpot.length > 1 &&
-      !['B04', 'B23', 'R22', 'R10', 'G02', 'G21', 'Y30', 'Y42']
-          .contains(attackerToken.positionId)) {
-    // Batch token movements
-    final tokensToMove = tokensOnSpot
-        .where((token) => token.playerId != attackerToken.playerId)
-        .toList();
-
-    if (tokensToMove.isNotEmpty) {
-      wasTokenAttacked = true;
-    }
-
-    // Wait for all movements to complete
-    await Future.wait(tokensToMove.map((token) => moveBackward(
-          world: world,
-          token: token,
-          tokenPath: GameState().getTokenPath(token.playerId),
-          ludoBoard: GameState().ludoBoard as PositionComponent,
-        )));
-  }
-
-  // Grant another turn or switch to next player
-  final player = GameState()
-      .players
-      .firstWhere((player) => player.playerId == attackerToken.playerId);
-
-  if (wasTokenAttacked) {
-    if (player.hasRolledThreeConsecutiveSixes()) {
-      player.resetExtraTurns();
-    }
-    player.grantAnotherTurn();
-  } else {
-    if (GameState().diceNumber != 6) {
-      GameState().switchToNextPlayer();
-    }
-  }
-
-  player.enableDice = true;
-
-  if (GameState().diceNumber == 6 || wasTokenAttacked == true) {
-    final lowerController = world.children.whereType<LowerController>().first;
-    final upperController = world.children.whereType<UpperController>().first;
-    lowerController.showPointer(player.playerId);
-    upperController.showPointer(player.playerId);
-  }
-
-  for (var token in player.tokens) {
-    token.enableToken = false;
-  }
-
-  // Call the function to resize tokens after moveBackward is complete
-  resizeTokensOnSpot(world);
-}
-
-void resizeTokensOnSpot(World world) {
-  final positionIncrements = {
-    1: 0,
-    2: 10,
-    3: 5,
-  };
-
-  // Group tokens by position ID
-  final Map<String, List<Token>> tokensByPositionId = {};
-  for (var token in TokenManager().allTokens) {
-    if (!tokensByPositionId.containsKey(token.positionId)) {
-      tokensByPositionId[token.positionId] = [];
-    }
-    tokensByPositionId[token.positionId]!.add(token);
-  }
-
-  tokensByPositionId.forEach((positionId, tokenList) {
-    // Precompute spot global position and adjusted position
-    final spot = SpotManager().findSpotById(positionId);
-
-    // Compute size factor and position increment
-    final positionIncrement = positionIncrements[tokenList.length] ?? 5;
-
-    // Resize and reposition tokens
-    for (var i = 0; i < tokenList.length; i++) {
-      final token = tokenList[i];
-      if (token.state == TokenState.inBase) {
-        token.position = spot.position;
-      } else if (token.state == TokenState.onBoard ||
-          token.state == TokenState.inHome) {
-        token.position = Vector2(
-            spot.tokenPosition.x + i * positionIncrement, spot.tokenPosition.y);
-      }
-    }
-  });
-}
-
-void addTokenTrail(List<Token> tokensInBase, List<Token> tokensOnBoard) {
-  var trailingTokens = [];
-
-  for (var token in tokensOnBoard) {
-    if (!token.spaceToMove()) {
-      continue;
-    }
-    trailingTokens.add(token);
-  }
-
-  if (GameState().diceNumber == 6) {
-    for (var token in tokensInBase) {
-      trailingTokens.add(token);
-    }
-  }
-
-  for (var token in trailingTokens) {
-    token.enableCircleAnimation();
-  }
-}
-
-Future<void> moveBackward({
-  required World world,
-  required Token token,
-  required List<String> tokenPath,
-  required PositionComponent ludoBoard,
-}) async {
-  final currentIndex = tokenPath.indexOf(token.positionId);
-  const finalIndex = 0;
-
-  // Preload audio to avoid delays during playback
-  bool audioPlayed = false;
-
-  for (int i = currentIndex; i >= finalIndex; i--) {
-    token.positionId = tokenPath[i];
-
-    if (!audioPlayed) {
-      FlameAudio.play('move.mp3');
-      audioPlayed = true;
-    }
-
-    await _applyEffect(
-      token,
-      MoveToEffect(
-        SpotManager()
-            .getSpots()
-            .firstWhere((spot) => spot.uniqueId == token.positionId)
-            .tokenPosition,
-        EffectController(duration: 0.1, curve: Curves.easeInOut),
-      ),
-    );
-  }
-
-  if (token.playerId == 'BP') {
-    await moveTokenToBase(
-      world: world,
-      token: token,
-      tokenBase: TokenManager().blueTokensBase,
-      homeSpotIndex: 6,
-      ludoBoard: ludoBoard,
-    );
-  } else if (token.playerId == 'GP') {
-    await moveTokenToBase(
-      world: world,
-      token: token,
-      tokenBase: TokenManager().greenTokensBase,
-      homeSpotIndex: 2,
-      ludoBoard: ludoBoard,
-    );
-  } else if (token.playerId == 'RP') {
-    await moveTokenToBase(
-      world: world,
-      token: token,
-      tokenBase: TokenManager().redTokensBase,
-      homeSpotIndex: 0,
-      ludoBoard: ludoBoard,
-    );
-  } else if (token.playerId == 'YP') {
-    await moveTokenToBase(
-      world: world,
-      token: token,
-      tokenBase: TokenManager().yellowTokensBase,
-      homeSpotIndex: 8,
-      ludoBoard: ludoBoard,
-    );
-  }
-}
-
-Future<void> moveForward({
-  required World world,
-  required Token token,
-  required List<String> tokenPath,
-  required int diceNumber,
-}) async {
-  // get all spots
-  final currentIndex = tokenPath.indexOf(token.positionId);
-  final finalIndex = currentIndex + diceNumber;
-
-  for (int i = currentIndex + 1; i <= finalIndex && i < tokenPath.length; i++) {
-    token.positionId = tokenPath[i];
-    await _applyEffect(
-      token,
-      MoveToEffect(
-        SpotManager()
-            .getSpots()
-            .firstWhere((spot) => spot.uniqueId == token.positionId)
-            .tokenPosition,
-        EffectController(duration: 0.12, curve: Curves.easeInOut),
-      ),
-    );
-
-    // Add a small delay to reduce CPU strain and smooth the animation
-    Future.delayed(const Duration(milliseconds: 120));
-  }
-
-  // if token is in home
-  bool isTokenInHome = await checkTokenInHomeAndHandle(token, world);
-
-  if (isTokenInHome) {
-    resizeTokensOnSpot(world);
-  } else {
-    tokenCollision(world, token);
-  }
-  clearTokenTrail();
-  
-}
-
-void clearTokenTrail() {
-  final tokens = TokenManager().allTokens;
-  for (var token in tokens) {
-    token.disableCircleAnimation();
-  }
-}
-
-Future<void> _applyEffect(PositionComponent component, Effect effect) {
-  final completer = Completer<void>();
-  effect.onComplete = completer.complete;
-  component.add(effect);
-  return completer.future;
-}
-
-Future<void> moveTokenToBase({
-  required World world,
-  required Token token,
-  required Map<String, String> tokenBase,
-  required int homeSpotIndex,
-  required PositionComponent ludoBoard,
-}) async {
-  for (var entry in tokenBase.entries) {
-    var tokenId = entry.key;
-    var homePosition = entry.value;
-    if (token.tokenId == tokenId) {
-      token.positionId = homePosition;
-      token.state = TokenState.inBase;
-    }
-  }
-
-  await _applyEffect(
-    token,
-    MoveToEffect(
-      SpotManager().findSpotById(token.positionId).position,
-      EffectController(duration: 0.03, curve: Curves.easeInOut),
-    ),
-  );
-  Future.delayed(const Duration(milliseconds: 30));
-}
-
-Future<bool> checkTokenInHomeAndHandle(Token token, World world) async {
-  // Define home position IDs
-  const homePositions = ['BF', 'GF', 'YF', 'RF'];
-
-  // Check if the token is in home
-  if (!homePositions.contains(token.positionId)) return false;
-
-  token.state = TokenState.inHome;
-
-  // Cache players from GameState
-  // final players = GameState().players;
-  final player =
-      GameState().players.firstWhere((p) => p.playerId == token.playerId);
-  player.totalTokensInHome++;
-
-  // Handle win condition
-  if (player.totalTokensInHome == 4) {
-    player.hasWon = true;
-
-    // Get winners and non-winners
-    final playersWhoWon = GameState().players.where((p) => p.hasWon).toList();
-    final playersWhoNotWon =
-        GameState().players.where((p) => !p.hasWon).toList();
-
-    // End game condition
-    if (playersWhoWon.length == GameState().players.length - 1) {
-      playersWhoNotWon.first.rank =
-          GameState().players.length; // Rank last player
-      player.rank = playersWhoWon.length; // Set rank for current player
-      // Disable dice for all players
-      for (var p in GameState().players) {
-        p.enableDice = false;
-      }
-      for (var t in TokenManager().allTokens) {
-        t.enableToken = false;
-      }
-      EventBus().emit(OpenPlayerModalEvent());
-    } else {
-      // Set rank for current player
-      player.rank = playersWhoWon.length;
-    }
-    return true;
-  }
-
-  // Grant another turn if not all tokens are home
-
-  player.enableDice = true;
-  final lowerController = world.children.whereType<LowerController>().first;
-  lowerController.showPointer(player.playerId);
-  final upperController = world.children.whereType<UpperController>().first;
-  upperController.showPointer(player.playerId);
-
-  // Disable tokens for current player
-  for (var t in player.tokens) {
-    t.enableToken = false;
-  }
-
-  // Reset extra turns if applicable
-  if (player.hasRolledThreeConsecutiveSixes()) {
-    await player.resetExtraTurns();
-  }
-
-  player.grantAnotherTurn();
-  return true;
-}

--- a/lib/state/audio_manager.dart
+++ b/lib/state/audio_manager.dart
@@ -4,12 +4,10 @@ class AudioManager {
   static AudioPool? _diceSoundPool;
 
   static Future<void> initialize() async {
-    if (_diceSoundPool == null) {
-      _diceSoundPool = await AudioPool.createFromAsset(
-        path: 'audio/dice.mp3',
-        maxPlayers: 3,
-      );
-    }
+    _diceSoundPool ??= await AudioPool.createFromAsset(
+      path: 'audio/dice.mp3',
+      maxPlayers: 3,
+    );
   }
 
   static Future<StopFunction> playDiceSound({double volume = 1.0}) async {

--- a/lib/state/game_state.dart
+++ b/lib/state/game_state.dart
@@ -1,5 +1,14 @@
+import 'dart:async';
+import 'dart:math';
 import 'package:flame/components.dart';
+import 'package:flame/effects.dart';
+import 'package:flame_audio/flame_audio.dart';
 import 'package:flutter/material.dart';
+import 'package:ludo/component/ui_components/token.dart';
+import 'package:ludo/state/token_manager.dart';
+import 'package:ludo/component/ui_components/spot.dart';
+import 'package:ludo/component/controller/lower_controller.dart';
+import 'package:ludo/component/controller/upper_controller.dart';
 
 import 'player.dart';
 import 'event_bus.dart';
@@ -356,5 +365,476 @@ class GameState {
 
   List<String> getTokenPath(String playerId) {
     return tokenPaths[playerId] ?? [];
+  }
+
+  Future<void> _applyEffect(PositionComponent component, Effect effect) {
+    final completer = Completer<void>();
+    effect.onComplete = completer.complete;
+    component.add(effect);
+    return completer.future;
+  }
+
+  void moveOutOfBase({
+    required World world,
+    required Token token,
+    required List<String> tokenPath,
+  }) async {
+    token.positionId = tokenPath.first;
+    token.state = TokenState.onBoard;
+
+    await _applyEffect(
+        token,
+        MoveToEffect(SpotManager().findSpotById(tokenPath.first).tokenPosition,
+            EffectController(duration: 0.1, curve: Curves.easeInOut)));
+
+    tokenCollision(world, token);
+  }
+
+  void tokenCollision(World world, Token attackerToken) async {
+    final tokensOnSpot = TokenManager()
+        .allTokens
+        .where((token) => token.positionId == attackerToken.positionId)
+        .toList();
+
+    bool wasTokenAttacked = false;
+
+    // Safe spots list (replaces inline magic array check)
+    const safeSpots = ['B04', 'B23', 'R22', 'R10', 'G02', 'G21', 'Y30', 'Y42'];
+
+    if (tokensOnSpot.length > 1 &&
+        !safeSpots.contains(attackerToken.positionId)) {
+      final tokensToMove = tokensOnSpot
+          .where((token) => token.playerId != attackerToken.playerId)
+          .toList();
+
+      if (tokensToMove.isNotEmpty) {
+        wasTokenAttacked = true;
+      }
+
+      await Future.wait(tokensToMove.map((token) => moveBackward(
+            world: world,
+            token: token,
+            tokenPath: getTokenPath(token.playerId),
+            ludoBoard: ludoBoard as PositionComponent,
+          )));
+    }
+
+    final player = players.firstWhere((p) => p.playerId == attackerToken.playerId);
+
+    if (wasTokenAttacked) {
+      if (player.hasRolledThreeConsecutiveSixes()) {
+        player.resetExtraTurns();
+      }
+      player.grantAnotherTurn();
+    } else {
+      if (diceNumber != 6) {
+        switchToNextPlayer();
+      }
+    }
+
+    player.enableDice = true;
+
+    if (diceNumber == 6 || wasTokenAttacked) {
+      final lowerController = world.children.whereType<LowerController>().first;
+      final upperController = world.children.whereType<UpperController>().first;
+      lowerController.showPointer(player.playerId);
+      upperController.showPointer(player.playerId);
+    }
+
+    for (var token in player.tokens) {
+      token.enableToken = false;
+    }
+
+    resizeTokensOnSpot(world);
+  }
+
+  void resizeTokensOnSpot(World world) {
+    const positionIncrements = {
+      1: 0,
+      2: 10,
+      3: 5,
+    };
+
+    final Map<String, List<Token>> tokensByPositionId = {};
+    for (var token in TokenManager().allTokens) {
+      if (!tokensByPositionId.containsKey(token.positionId)) {
+        tokensByPositionId[token.positionId] = [];
+      }
+      tokensByPositionId[token.positionId]!.add(token);
+    }
+
+    tokensByPositionId.forEach((positionId, tokenList) {
+      final spot = SpotManager().findSpotById(positionId);
+      final positionIncrement = positionIncrements[tokenList.length] ?? 5;
+
+      for (var i = 0; i < tokenList.length; i++) {
+        final token = tokenList[i];
+        if (token.state == TokenState.inBase) {
+          token.position = spot.position;
+        } else if (token.state == TokenState.onBoard ||
+            token.state == TokenState.inHome) {
+          token.position = Vector2(
+              spot.tokenPosition.x + i * positionIncrement, spot.tokenPosition.y);
+        }
+      }
+    });
+  }
+
+  void addTokenTrail(List<Token> tokensInBase, List<Token> tokensOnBoard) {
+    final trailingTokens = <Token>[];
+
+    for (var token in tokensOnBoard) {
+      if (!token.spaceToMove()) {
+        continue;
+      }
+      trailingTokens.add(token);
+    }
+
+    if (diceNumber == 6) {
+      for (var token in tokensInBase) {
+        trailingTokens.add(token);
+      }
+    }
+
+    for (var token in trailingTokens) {
+      token.enableCircleAnimation();
+    }
+  }
+
+  Future<void> moveBackward({
+    required World world,
+    required Token token,
+    required List<String> tokenPath,
+    required PositionComponent ludoBoard,
+  }) async {
+    final currentIndex = tokenPath.indexOf(token.positionId);
+    const finalIndex = 0;
+    bool audioPlayed = false;
+
+    for (int i = currentIndex; i >= finalIndex; i--) {
+      token.positionId = tokenPath[i];
+
+      if (!audioPlayed) {
+        FlameAudio.play('move.mp3');
+        audioPlayed = true;
+      }
+
+      await _applyEffect(
+        token,
+        MoveToEffect(
+          SpotManager()
+              .getSpots()
+              .firstWhere((spot) => spot.uniqueId == token.positionId)
+              .tokenPosition,
+          EffectController(duration: 0.1, curve: Curves.easeInOut),
+        ),
+      );
+    }
+
+    if (token.playerId == 'BP') {
+      await moveTokenToBase(
+        world: world,
+        token: token,
+        tokenBase: TokenManager().blueTokensBase,
+        homeSpotIndex: 6,
+        ludoBoard: ludoBoard,
+      );
+    } else if (token.playerId == 'GP') {
+      await moveTokenToBase(
+        world: world,
+        token: token,
+        tokenBase: TokenManager().greenTokensBase,
+        homeSpotIndex: 2,
+        ludoBoard: ludoBoard,
+      );
+    } else if (token.playerId == 'RP') {
+      await moveTokenToBase(
+        world: world,
+        token: token,
+        tokenBase: TokenManager().redTokensBase,
+        homeSpotIndex: 0,
+        ludoBoard: ludoBoard,
+      );
+    } else if (token.playerId == 'YP') {
+      await moveTokenToBase(
+        world: world,
+        token: token,
+        tokenBase: TokenManager().yellowTokensBase,
+        homeSpotIndex: 8,
+        ludoBoard: ludoBoard,
+      );
+    }
+  }
+
+  Future<void> moveForward({
+    required World world,
+    required Token token,
+    required List<String> tokenPath,
+    required int diceNumber,
+  }) async {
+    final currentIndex = tokenPath.indexOf(token.positionId);
+    final finalIndex = currentIndex + diceNumber;
+
+    for (int i = currentIndex + 1; i <= finalIndex && i < tokenPath.length; i++) {
+      token.positionId = tokenPath[i];
+      await _applyEffect(
+        token,
+        MoveToEffect(
+          SpotManager()
+              .getSpots()
+              .firstWhere((spot) => spot.uniqueId == token.positionId)
+              .tokenPosition,
+          EffectController(duration: 0.12, curve: Curves.easeInOut),
+        ),
+      );
+
+      // Add a small delay to reduce CPU strain and smooth the animation
+      await Future.delayed(const Duration(milliseconds: 120));
+    }
+
+    bool isTokenInHome = await checkTokenInHomeAndHandle(token, world);
+
+    if (isTokenInHome) {
+      resizeTokensOnSpot(world);
+    } else {
+      tokenCollision(world, token);
+    }
+    clearTokenTrail();
+  }
+
+  void clearTokenTrail() {
+    for (var token in TokenManager().allTokens) {
+      token.disableCircleAnimation();
+    }
+  }
+
+  Future<void> moveTokenToBase({
+    required World world,
+    required Token token,
+    required Map<String, String> tokenBase,
+    required int homeSpotIndex,
+    required PositionComponent ludoBoard,
+  }) async {
+    for (var entry in tokenBase.entries) {
+      var tokenId = entry.key;
+      var homePosition = entry.value;
+      if (token.tokenId == tokenId) {
+        token.positionId = homePosition;
+        token.state = TokenState.inBase;
+      }
+    }
+
+    await _applyEffect(
+      token,
+      MoveToEffect(
+        SpotManager().findSpotById(token.positionId).position,
+        EffectController(duration: 0.03, curve: Curves.easeInOut),
+      ),
+    );
+    await Future.delayed(const Duration(milliseconds: 30));
+  }
+
+  Future<bool> checkTokenInHomeAndHandle(Token token, World world) async {
+    const homePositions = ['BF', 'GF', 'YF', 'RF'];
+
+    if (!homePositions.contains(token.positionId)) return false;
+
+    token.state = TokenState.inHome;
+
+    final player = players.firstWhere((p) => p.playerId == token.playerId);
+    player.totalTokensInHome++;
+
+    if (player.totalTokensInHome == 4) {
+      player.hasWon = true;
+
+      final playersWhoWon = players.where((p) => p.hasWon).toList();
+      final playersWhoNotWon = players.where((p) => !p.hasWon).toList();
+
+      if (playersWhoWon.length == players.length - 1) {
+        playersWhoNotWon.first.rank = players.length;
+        player.rank = playersWhoWon.length;
+        for (var p in players) {
+          p.enableDice = false;
+        }
+        for (var t in TokenManager().allTokens) {
+          t.enableToken = false;
+        }
+        EventBus().emit(OpenPlayerModalEvent());
+      } else {
+        player.rank = playersWhoWon.length;
+      }
+      return true;
+    }
+
+    player.enableDice = true;
+    final lowerController = world.children.whereType<LowerController>().first;
+    lowerController.showPointer(player.playerId);
+    final upperController = world.children.whereType<UpperController>().first;
+    upperController.showPointer(player.playerId);
+
+    for (var t in player.tokens) {
+      t.enableToken = false;
+    }
+
+    if (player.hasRolledThreeConsecutiveSixes()) {
+      await player.resetExtraTurns();
+    }
+
+    player.grantAnotherTurn();
+    return true;
+  }
+
+  int rollDice() {
+    diceNumber = Random().nextInt(6) + 1;
+    return diceNumber;
+  }
+
+  void resolveDiceRoll(World world) {
+    final handleRoll = diceNumber == 6 ? _handleSixRoll : _handleNonSixRoll;
+    handleRoll(world);
+  }
+
+  void _handleSixRoll(World world) {
+    final player = currentPlayer;
+    player.grantAnotherTurn();
+
+    if (player.hasRolledThreeConsecutiveSixes()) {
+      switchToNextPlayer();
+      return;
+    }
+
+    final tokensInBase = player.tokens
+        .where((token) => token.state == TokenState.inBase)
+        .toList();
+
+    final tokensOnBoard = player.tokens
+        .where((token) => token.state == TokenState.onBoard)
+        .toList();
+
+    final movableTokens =
+        tokensOnBoard.where((token) => token.spaceToMove()).toList();
+
+    final allMovableTokens = [...movableTokens, ...tokensInBase];
+
+    if (allMovableTokens.length == 1) {
+      if (allMovableTokens.first.state == TokenState.inBase) {
+        moveOutOfBase(
+          world: world,
+          token: allMovableTokens.first,
+          tokenPath: getTokenPath(player.playerId),
+        );
+      } else if (allMovableTokens.first.state == TokenState.onBoard) {
+        moveForward(
+          world: world,
+          token: allMovableTokens.first,
+          tokenPath: getTokenPath(player.playerId),
+          diceNumber: diceNumber,
+        );
+      }
+      return;
+    } else if (allMovableTokens.length > 1) {
+      _enableManualTokenSelection(world, tokensInBase, tokensOnBoard);
+    } else if (allMovableTokens.isEmpty) {
+      switchToNextPlayer();
+      return;
+    }
+  }
+
+  void _handleNonSixRoll(World world) {
+    final player = currentPlayer;
+    final tokensOnBoard = player.tokens
+        .where((token) => token.state == TokenState.onBoard)
+        .toList();
+
+    if (tokensOnBoard.isEmpty) {
+      switchToNextPlayer();
+      return;
+    }
+
+    final movableTokens =
+        tokensOnBoard.where((token) => token.spaceToMove()).toList();
+    final tokensInBase = player.tokens
+        .where((token) => token.state == TokenState.inBase)
+        .toList();
+
+    if (movableTokens.length == 1) {
+      moveForward(
+        world: world,
+        token: movableTokens.first,
+        tokenPath: getTokenPath(player.playerId),
+        diceNumber: diceNumber,
+      );
+      return;
+    } else if (movableTokens.length > 1) {
+      _enableManualTokenSelection(world, tokensInBase, tokensOnBoard);
+    } else if (movableTokens.isEmpty) {
+      switchToNextPlayer();
+      return;
+    }
+  }
+
+  void _enableManualTokenSelection(
+      World world, List<Token> tokensInBase, List<Token> tokensOnBoard) {
+    final player = currentPlayer;
+    hidePointer();
+    player.enableDice = false;
+
+    for (var token in player.tokens) {
+      token.enableToken = true;
+    }
+    if (tokensInBase.isNotEmpty && tokensOnBoard.isNotEmpty) {
+      enableMoveFromBoth();
+      addTokenTrail(tokensInBase, tokensOnBoard);
+    } else if (tokensInBase.isNotEmpty) {
+      enableMoveFromBase();
+      addTokenTrail(tokensInBase, tokensOnBoard);
+    } else if (tokensOnBoard.isNotEmpty) {
+      addTokenTrail(tokensInBase, tokensOnBoard);
+      enableMoveOnBoard();
+    }
+  }
+
+  void handleTokenTap(World world, Token token) {
+    if (!token.spaceToMove() ||
+        !token.enableToken ||
+        (token.isInBase() && diceNumber != 6) ||
+        token.isInHome()) {
+      return;
+    }
+
+    token.enableToken = false;
+
+    if (currentPlayer.playerId != token.playerId) {
+      return;
+    }
+
+    for (var t in TokenManager().allTokens) {
+      t.disableCircleAnimation();
+      t.enableToken = false;
+    }
+
+    if (diceNumber == 6) {
+      if (token.state == TokenState.inBase && canMoveTokenFromBase) {
+        moveOutOfBase(
+            world: world,
+            token: token,
+            tokenPath: getTokenPath(token.playerId));
+      } else if (token.state == TokenState.onBoard && canMoveTokenOnBoard) {
+        moveForward(
+            world: world,
+            token: token,
+            tokenPath: getTokenPath(token.playerId),
+            diceNumber: diceNumber);
+      }
+      return;
+    }
+
+    if (token.state == TokenState.onBoard && canMoveTokenOnBoard) {
+      moveForward(
+          world: world,
+          token: token,
+          tokenPath: getTokenPath(token.playerId),
+          diceNumber: diceNumber);
+    }
   }
 }

--- a/lib/state/home_spot_manager.dart
+++ b/lib/state/home_spot_manager.dart
@@ -1,0 +1,24 @@
+import 'package:ludo/component/home/home_spot.dart';
+
+class HomeSpotManager {
+  static final HomeSpotManager _instance = HomeSpotManager._internal();
+  final Map<String, HomeSpot> _homeSpotMap = {};
+
+  HomeSpotManager._internal();
+
+  factory HomeSpotManager() {
+    return _instance;
+  }
+
+  void addHomeSpot(HomeSpot spot) {
+    _homeSpotMap[spot.uniqueId] = spot;
+  }
+
+  HomeSpot? getHomeSpotById(String uniqueId) {
+    return _homeSpotMap[uniqueId];
+  }
+
+  void clearHomeSpots() {
+    _homeSpotMap.clear();
+  }
+}


### PR DESCRIPTION
This PR refactors the codebase to separate game logic and rules from UI rendering components, introduces a layout registry manager, cleans up top-level functions, and restores standard Dart guidelines.

### Changes Summary
1. Centralized game mechanics and movement resolution inside `GameState` controller.
2. Created `HomeSpotManager` self-registering registry to clean up fragile widget tree traversals.
3. Decoupled `LudoDice` and `Token` UI components.
4. Restored and satisfied standard Dart lints.

Verified clean run on Pixel 7 Android emulator.